### PR TITLE
Fix Turnstile script firing callback before DOM loaded

### DIFF
--- a/Resources/views/Integration/turnstile.html.twig
+++ b/Resources/views/Integration/turnstile.html.twig
@@ -213,7 +213,7 @@ Varables
 
             <div id="provider"></div>
         {% else %}
-            <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=onloadTurnstileCallback"></script>
+            <script defer src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=onloadTurnstileCallback"></script>
         {% endif %}
 
         <div {% for attrName, attrValue in containerAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>


### PR DESCRIPTION
When "Explicit Consent" is disabled in the field settings for the Turnstile field, the Turnstile script loads and fires the callback function before the DOM has fully loaded. Since the DOM hasn't fully loaded yet, the `document.getElementById("cf_turnstile")` in `onloadTurnstileCallback()` returns `null` and Turnstile fails to render with the error `Uncaught TurnstileError: [Cloudflare Turnstile] Invalid type for parameter "container", expected "string" or an implementation of "HTMLElement".`

This PR sets the `defer` attribute on the Turnstile script tag so that it does not execute until the DOM is fully loaded.

Fixes https://github.com/FireMultimedia/mautic-multi-captcha-bundle/issues/6 